### PR TITLE
Updated API version for SYNO.API.Auth

### DIFF
--- a/bin/check_hyperbackup.php
+++ b/bin/check_hyperbackup.php
@@ -11,7 +11,7 @@
  * - backup			-> OK
  * - detect			-> OK
  * - waiting			-> OK
- * - version_deleting		-> OK
+ * - version_deleting		-> WARNING
  * 
  * Existing statuses for last_bkp_result :
  * - done			-> OK
@@ -174,7 +174,8 @@ if(!isset($options['p'])) {echo "Password not defined.\n";print_help();exit;} el
 			$status_n = max(0, $status_n);
 		}
 		elseif($task_status === "version_deleting") { //Ongoing deletion of old version
-                        $status_n = max(0, $status_n);
+                        $status_n = max(1, $status_n);
+			$s = 1;
                 }
 		elseif($last_bkp_status === "resuming" && $task_status === "backup") { // Resuming backup
 			$status_n = max(0, $status_n);

--- a/bin/check_hyperbackup.php
+++ b/bin/check_hyperbackup.php
@@ -12,11 +12,13 @@
  * - detect			-> OK
  * - waiting			-> OK
  * - version_deleting		-> WARNING
+ * - preparing_version_deleting	-> WARNING
  * 
  * Existing statuses for last_bkp_result :
  * - done			-> OK
  * - backingup			-> OK
  * - version_deleting		-> OK
+ * - preparing_version_deleting	-> WARNING
  * 
  ************************/
 $debug = false;
@@ -157,6 +159,8 @@ if(!isset($options['p'])) {echo "Password not defined.\n";print_help();exit;} el
 			$status_n = max(0, $status_n);
                 elseif($last_bkp_status === "version_deleting")
                         $status_n = max(0, $status_n);
+                elseif($last_bkp_status === "preparing_version_deleting")
+                        $status_n = max(0, $status_n);
 		else
 			$status_n = max(2, $status_n);
 			
@@ -173,7 +177,7 @@ if(!isset($options['p'])) {echo "Password not defined.\n";print_help();exit;} el
 		elseif($task_status === "backup") { // Ongoing backup
 			$status_n = max(0, $status_n);
 		}
-		elseif($task_status === "version_deleting") { //Ongoing deletion of old version
+		elseif($task_status === "version_deleting" || $task_status === "preparing_version_deleting") { //Ongoing/praparation of deletion of old version
                         $status_n = max(1, $status_n);
 			$s = 1;
                 }

--- a/bin/check_hyperbackup.php
+++ b/bin/check_hyperbackup.php
@@ -101,7 +101,7 @@ if(!isset($options['p'])) {echo "Password not defined.\n";print_help();exit;} el
 
     /* API VERSIONS */
     //SYNO.API.Auth
-    $vAuth = 2;
+    $vAuth = 6;
     
 	$api = "SYNO.Backup.Task";
     //$api = "SYNO.DownloadStation.Task";

--- a/bin/check_hyperbackup.php
+++ b/bin/check_hyperbackup.php
@@ -12,13 +12,13 @@
  * - detect			-> OK
  * - waiting			-> OK
  * - version_deleting		-> WARNING
- * - preparing_version_deleting	-> WARNING
+ * - preparing_version_delete	-> WARNING
  * 
  * Existing statuses for last_bkp_result :
  * - done			-> OK
  * - backingup			-> OK
  * - version_deleting		-> OK
- * - preparing_version_deleting	-> WARNING
+ * - preparing_version_delete	-> OK
  * 
  ************************/
 $debug = false;
@@ -159,7 +159,7 @@ if(!isset($options['p'])) {echo "Password not defined.\n";print_help();exit;} el
 			$status_n = max(0, $status_n);
                 elseif($last_bkp_status === "version_deleting")
                         $status_n = max(0, $status_n);
-                elseif($last_bkp_status === "preparing_version_deleting")
+                elseif($last_bkp_status === "preparing_version_delete")
                         $status_n = max(0, $status_n);
 		else
 			$status_n = max(2, $status_n);
@@ -177,7 +177,7 @@ if(!isset($options['p'])) {echo "Password not defined.\n";print_help();exit;} el
 		elseif($task_status === "backup") { // Ongoing backup
 			$status_n = max(0, $status_n);
 		}
-		elseif($task_status === "version_deleting" || $task_status === "preparing_version_deleting") { //Ongoing/praparation of deletion of old version
+		elseif($task_status === "version_deleting" || $task_status === "preparing_version_delete") { //Ongoing/praparation of deletion of old version
                         $status_n = max(1, $status_n);
 			$s = 1;
                 }

--- a/bin/check_hyperbackup.php
+++ b/bin/check_hyperbackup.php
@@ -10,11 +10,13 @@
  * - none			-> OK
  * - backup			-> OK
  * - detect			-> OK
- * - waiting		-> OK
+ * - waiting			-> OK
+ * - version_deleting		-> OK
  * 
  * Existing statuses for last_bkp_result :
  * - done			-> OK
- * - backupingup	-> OK
+ * - backingup			-> OK
+ * - version_deleting		-> OK
  * 
  ************************/
 $debug = false;
@@ -153,6 +155,8 @@ if(!isset($options['p'])) {echo "Password not defined.\n";print_help();exit;} el
 			$status_n = max(1, $status_n);
 		elseif($last_bkp_status === "backingup") 
 			$status_n = max(0, $status_n);
+                elseif($last_bkp_status === "version_deleting")
+                        $status_n = max(0, $status_n);
 		else
 			$status_n = max(2, $status_n);
 			
@@ -169,6 +173,9 @@ if(!isset($options['p'])) {echo "Password not defined.\n";print_help();exit;} el
 		elseif($task_status === "backup") { // Ongoing backup
 			$status_n = max(0, $status_n);
 		}
+		elseif($task_status === "version_deleting") { //Ongoing deletion of old version
+                        $status_n = max(0, $status_n);
+                }
 		elseif($last_bkp_status === "resuming" && $task_status === "backup") { // Resuming backup
 			$status_n = max(0, $status_n);
 		}


### PR DESCRIPTION
Event though `/webapi/entry.cgi?api=SYNO.API.Info&version=1&method=query&query=SYNO.API.Auth` returns `{"data":{"SYNO.API.Auth":{"maxVersion":7,"minVersion":1,"path":"entry.cgi"}},"success":true}`  only version 6 seems to work.